### PR TITLE
Closes #44 Add explicit failure for deprecated input formats

### DIFF
--- a/__dev9/VampireNumber.java
+++ b/__dev9/VampireNumber.java
@@ -1,0 +1,48 @@
+package com.thealgorithms.maths;
+
+import java.util.ArrayList;
+
+/**
+ * In number theory, a vampire number (or true vampire number) is a composite
+ * natural number with an even number of digits, that can be factored into two
+ * natural numbers each with half as many digits as the original number and not
+ * both with trailing zeroes, where the two factors contain precisely all the
+ * digits of the original number, in any order, counting multiplicity. The first
+ * vampire number is 1260 = 21 × 60.
+ *
+ * @see <a href='https://en.wikipedia.org/wiki/Vampire_number'>Vampire number on Wikipedia</a>
+ */
+public final class VampireNumber {
+    // Forbid instantiation.
+    private VampireNumber() {
+    }
+
+    static boolean isVampireNumber(int a, int b, boolean ignorePseudoVampireNumbers) {
+        // Pseudo vampire numbers don't have to be of n/2 digits. E.g., 126 = 6 x 21 is such a number.
+        if (ignorePseudoVampireNumbers && String.valueOf(a).length() != String.valueOf(b).length()) {
+            return false;
+        }
+
+        String mulDigits = splitIntoSortedDigits(a * b);
+        String factorDigits = splitIntoSortedDigits(a, b);
+
+        return mulDigits.equals(factorDigits);
+    }
+
+    // Method to split a pair of numbers to digits and sort them in the ascending order.
+    static String splitIntoSortedDigits(int... nums) {
+        // Collect all digits in a list.
+        ArrayList<Integer> digits = new ArrayList<>();
+        for (int num : nums) {
+            while (num > 0) {
+                digits.add(num % 10);
+                num /= 10;
+            }
+        }
+
+        // Sort all digits and convert to String.
+        StringBuilder res = new StringBuilder();
+        digits.stream().sorted().forEach(res::append);
+        return res.toString();
+    }
+}

--- a/__dev9/comb_sort.dart
+++ b/__dev9/comb_sort.dart
@@ -1,0 +1,43 @@
+// function for combsort
+void combSort(List list) {
+  int gpVal = list.length;
+  double shrink = 1.3;
+  bool sortedBool = false;
+
+  while (!sortedBool) {
+    gpVal = (gpVal / shrink).floor();
+    if (gpVal > 1) {
+      sortedBool = false;
+    } else {
+      gpVal = 1;
+      sortedBool = true;
+    }
+
+    int i = 0;
+    while (i + gpVal < list.length) {
+      if (list[i] > list[i + gpVal]) {
+        swap(list, i, gpVal);
+        sortedBool = false;
+      }
+      i++;
+    }
+  }
+}
+
+// function to swap the values
+void swap(List list, int i, int gpVal) {
+  int temp = list[i];
+  list[i] = list[i + gpVal];
+  list[i + gpVal] = temp;
+}
+
+void main() {
+  //Get the dummy array
+  List arr = [1, 451, 562, 2, 99, 78, 5];
+  // for printing the array before sorting
+  print("Before sorting the array: $arr\n");
+  // applying combSort function
+  combSort(arr);
+  // printing the sortedBool value
+  print("After sorting the array: $arr");
+}

--- a/__dev9/sol20.dart
+++ b/__dev9/sol20.dart
@@ -1,0 +1,45 @@
+/*
+Problem 20: Factorial digit sum 
+
+n! means n × (n − 1) × ... × 3 × 2 × 1
+For example, 10! = 10 × 9 × ... × 3 × 2 × 1 = 3628800,
+and the sum of the digits in the number 10! is 3 + 6 + 2 + 8 + 8 + 0 + 0 = 27.
+Find the sum of the digits in the number 100!
+*/
+
+import 'package:test/test.dart';
+
+// To Calculate Factorial
+int factorial(int number) {
+  int factorial = 1;
+  for (int i = number; i >= 1; i--) {
+    factorial *= i;
+  }
+  return factorial;
+}
+
+// To Calculate Sum
+int sum(int number) {
+  int sum = 0;
+  for (int i = factorial(number); i > 0; i = (i / 10).floor()) {
+    sum += (i % 10);
+  }
+  return sum;
+}
+
+// Driver Code
+void main() {
+  group("Solution 20", () {
+    test("Test 1", () {
+      expect(1, sum(1));
+    });
+
+    test("Test 2", () {
+      expect(3, sum(5));
+    });
+
+    test("Test 3", () {
+      expect(27, sum(10));
+    });
+  });
+}


### PR DESCRIPTION
44 Closing the bug report due to a lack of minimal reproducible sequence data or logs. Without the specific FASTQ headers causing the failure, we cannot verify the claimed regression in the sequence-masker. The user is welcome to re-open once the necessary diagnostic information is provided.